### PR TITLE
reuse leveldb connection

### DIFF
--- a/mirage.go
+++ b/mirage.go
@@ -16,14 +16,17 @@ type Mirage struct {
 	WebApi       *WebApi
 	ReverseProxy *ReverseProxy
 	Docker       *Docker
+	Storage      *MirageStorage
 }
 
 func Setup(cfg *Config) {
+	ms := NewMirageStorage()
 	m := &Mirage{
 		Config:       cfg,
 		WebApi:       NewWebApi(cfg),
 		ReverseProxy: NewReverseProxy(cfg),
-		Docker:       NewDocker(cfg),
+		Docker:       NewDocker(cfg, ms),
+		Storage:      ms,
 	}
 
 	infolist, err := m.Docker.List()
@@ -86,7 +89,7 @@ func (m *Mirage) ServeHTTPWithPort(w http.ResponseWriter, req *http.Request, por
 
 func (m *Mirage) isDockerHost(host string) bool {
 	if strings.HasSuffix(host, m.Config.Host.ReverseProxySuffix) {
-		ms := NewMirageStorage()
+		ms := m.Storage
 		subdomainList, err := ms.GetSubdomainList()
 		if err != nil {
 			return false


### PR DESCRIPTION
mirage crashed and data directory was broken.

``` plain
2014/12/07 14:23:25 leveldb: could not open manifest file "MANIFEST-000606" for DB "./data": open ./data/MANIFEST-000606: no such file or directory
```

I think leveldb-go is goroutine-safe but locking database on file system does not work correctly.

https://gist.github.com/shogo82148/a643654c93cb5ae7a16a
