### PR TITLE
support websocket

### DIFF
--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strings"
 
 	//	"github.com/acidlemon/go-dumper"
+	"github.com/methane/rproxy"
 )
 
 type ReverseProxy struct {
@@ -50,7 +50,7 @@ func (r *ReverseProxy) AddSubdomain(subdomain string, ipaddress string) {
 	for _, v := range r.cfg.Listen.HTTP {
 		destUrlString := fmt.Sprintf("http://%s:%d", ipaddress, v.TargetPort)
 		destUrl, _ := url.Parse(destUrlString)
-		handler := httputil.NewSingleHostReverseProxy(destUrl)
+		handler := rproxy.NewSingleHostReverseProxy(destUrl)
 
 		handlers[v.ListenPort] = handler
 	}

--- a/webapi.go
+++ b/webapi.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/acidlemon/rocket/v1"
+	"gopkg.in/acidlemon/rocket.v1"
 )
 
 type WebApi struct {


### PR DESCRIPTION
- net/http/httputil をWebSocket対応したフォークの https://github.com/methane/rproxy に置き換えました
- acidlemon/rocketをgopkg.in経由でダウンロードするようにしました
