### PR TITLE
Enable to specify container name

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -40,7 +40,7 @@ func NewDocker(cfg *Config, ms *MirageStorage) *Docker {
 	return d
 }
 
-func (d *Docker) Launch(subdomain string, image string, option map[string]string) error {
+func (d *Docker) Launch(subdomain string, image string, name string, option map[string]string) error {
 	var dockerEnv []string = make([]string, 0)
 	for _, v := range d.cfg.Parameter {
 		if option[v.Name] == "" {
@@ -52,6 +52,7 @@ func (d *Docker) Launch(subdomain string, image string, option map[string]string
 	dockerEnv = append(dockerEnv, fmt.Sprintf("SUBDOMAIN=%s", subdomain))
 
 	opt := docker.CreateContainerOptions{
+		Name: name,
 		Config: &docker.Config{
 			Image: image,
 			Env:   dockerEnv,

--- a/html/launcher.html
+++ b/html/launcher.html
@@ -26,7 +26,7 @@
 
   <label for="name" class="col-md-2 text-right">container name </label>
   <input type="text" name="name" value="" id="container_name"
-         class="col-md-3" placeholder="john_titor">
+         class="col-md-3" placeholder="">
   <span class="col-md-7">optional: same as 'subdomain' if empty </span>
   <p class="col-md-12 text-right">
   <input type="submit" class="btn btn-primary">

--- a/html/launcher.html
+++ b/html/launcher.html
@@ -2,34 +2,33 @@
 
 <h1>Launch Container</h1>
 
-<div class="col-md-6">
+<div class="col-md-12">
 <form id="launcher" method="POST" action="/launch">
-  <label for="subdomain" class="col-md-3 text-right">subdomain </label>
+  <label for="subdomain" class="col-md-2 text-right">subdomain </label>
   <input type="text" name="subdomain" value="" id="subdomain"
-         class="col-md-7" placeholder="mybranch">
-  <p class="col-md-2">*Required</p>
+         class="col-md-3" placeholder="mybranch">
+  <p class="col-md-7">*Required</p>
 
 {{ range $param := .Parameters }}
 
-  <label for="{{ $param.Name }}" class="col-md-3 text-right">{{ $param.Name }} </label>
+  <label for="{{ $param.Name }}" class="col-md-2 text-right">{{ $param.Name }} </label>
   <input type="text" name="{{ $param.Name }}" value="" id="{{ $param.Name }}"
-         class="col-md-7" placeholder="your {{ $param.Name }}" />
-  <p class="col-md-2">{{ if $param.Required }}*Required {{ else}} (optional) {{ end }}</p>
+         class="col-md-3" placeholder="your {{ $param.Name }}" />
+  <p class="col-md-7">{{ if $param.Required }}*Required {{ else}} (optional) {{ end }}</p>
 
 {{ end }}
 
-  <label for="image" class="col-md-3 text-right">image </label>
+  <label for="image" class="col-md-2 text-right">image </label>
   <input type="text" name="image" value="{{ .DefaultImage }}" id="image"
-         class="col-md-7" placeholder="myapp:latest">
-  <span class="col-md-2">*Required</span>
-  <p class="col-md-12 text-right">
+         class="col-md-3" placeholder="myapp:latest">
+  <span class="col-md-7">*Required</span>
+  <p class="col-md-12 text-right"></p>
 
-  <label for="name" class="col-md-3 text-right">container name </label>
+  <label for="name" class="col-md-2 text-right">container name </label>
   <input type="text" name="name" value="" id="container_name"
-         class="col-md-7" placeholder="john_titor">
-  <span class="col-md-2">optional: same as 'subdomain' if empty </span>
+         class="col-md-3" placeholder="john_titor">
+  <span class="col-md-7">optional: same as 'subdomain' if empty </span>
   <p class="col-md-12 text-right">
-
   <input type="submit" class="btn btn-primary">
 </p>
 </form>

--- a/html/launcher.html
+++ b/html/launcher.html
@@ -23,6 +23,13 @@
          class="col-md-7" placeholder="myapp:latest">
   <span class="col-md-2">*Required</span>
   <p class="col-md-12 text-right">
+
+  <label for="name" class="col-md-3 text-right">container name </label>
+  <input type="text" name="name" value="" id="container_name"
+         class="col-md-7" placeholder="john_titor">
+  <span class="col-md-2">optional: same as 'subdomain' if empty </span>
+  <p class="col-md-12 text-right">
+
   <input type="submit" class="btn btn-primary">
 </p>
 </form>

--- a/webapi.go
+++ b/webapi.go
@@ -114,6 +114,14 @@ func (api *WebApi) launch(c rocket.CtxData) rocket.RenderVars {
 
 	subdomain, _ := c.ParamSingle("subdomain")
 	image, _ := c.ParamSingle("image")
+	name, _ := c.ParamSingle("name")
+
+	// Default container name is set same as subdomain when it is empty.
+	// 'name' will be unique because subdomains should not be duplicated.
+	// If the subdomain is duplicated, should returns error.
+	if name == "" {
+		name = subdomain
+	}
 
 	parameter, err := api.loadParameter(c)
 	if err != nil {
@@ -130,7 +138,7 @@ func (api *WebApi) launch(c rocket.CtxData) rocket.RenderVars {
 		status = fmt.Sprintf("parameter required: subdomain=%s, image=%s",
 			subdomain, image)
 	} else {
-		err := app.Docker.Launch(subdomain, image, parameter)
+		err := app.Docker.Launch(subdomain, image, name, parameter)
 		if err != nil {
 			status = err.Error()
 		}


### PR DESCRIPTION
I would like to specify container name because when we survey container's log, we cannot look up the container we want to do that immediately (docker container name is assigned at random...).

The following we want to do:

```
docker log -f <container_name>
```

If the feature is already provided or I was wrong, I'm sorry.

Thank you.