### PR TITLE
Default container name with random letters at suffix

### DIFF
--- a/html/launcher.html
+++ b/html/launcher.html
@@ -6,31 +6,32 @@
 <form id="launcher" method="POST" action="/launch">
   <label for="subdomain" class="col-md-2 text-right">subdomain </label>
   <input type="text" name="subdomain" value="" id="subdomain"
-         class="col-md-3" placeholder="mybranch">
-  <p class="col-md-7">*Required</p>
+         class="col-md-5" placeholder="mybranch">
+  <p class="col-md-5">*Required</p>
 
 {{ range $param := .Parameters }}
 
   <label for="{{ $param.Name }}" class="col-md-2 text-right">{{ $param.Name }} </label>
   <input type="text" name="{{ $param.Name }}" value="" id="{{ $param.Name }}"
-         class="col-md-3" placeholder="your {{ $param.Name }}" />
-  <p class="col-md-7">{{ if $param.Required }}*Required {{ else}} (optional) {{ end }}</p>
+         class="col-md-5" placeholder="your {{ $param.Name }}" />
+  <p class="col-md-5">{{ if $param.Required }}*Required {{ else}} (optional) {{ end }}</p>
 
 {{ end }}
 
   <label for="image" class="col-md-2 text-right">image </label>
   <input type="text" name="image" value="{{ .DefaultImage }}" id="image"
-         class="col-md-3" placeholder="myapp:latest">
-  <span class="col-md-7">*Required</span>
-  <p class="col-md-12 text-right"></p>
+         class="col-md-5" placeholder="myapp:latest">
+  <p class="col-md-5">*Required</p>
 
   <label for="name" class="col-md-2 text-right">container name </label>
   <input type="text" name="name" value="" id="container_name"
-         class="col-md-3" placeholder="">
-  <span class="col-md-7">optional: same as 'subdomain' if empty </span>
-  <p class="col-md-12 text-right">
-  <input type="submit" class="btn btn-primary">
-</p>
+         class="col-md-5" placeholder="default is 'subdomain-abcde' (random 5 letter suffix)">
+  <p class="col-md-5">Optional</p>
+
+  <p class="col-md-7"></p>
+  <p class="col-md-5 text-left">
+    <input type="submit" class="btn btn-primary">
+  </p>
 </form>
 </div>
 

--- a/main.go
+++ b/main.go
@@ -3,12 +3,18 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math/rand"
+	"time"
 )
 
 var (
 	version   string
 	buildDate string
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func main() {
 	confFile := flag.String("conf", "config.yml", "specify config file")

--- a/webapi.go
+++ b/webapi.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 
 	"gopkg.in/acidlemon/rocket.v2"
@@ -116,11 +117,8 @@ func (api *WebApi) launch(c rocket.CtxData) rocket.RenderVars {
 	image, _ := c.ParamSingle("image")
 	name, _ := c.ParamSingle("name")
 
-	// Default container name is set same as subdomain when it is empty.
-	// 'name' will be unique because subdomains should not be duplicated.
-	// If the subdomain is duplicated, should returns error.
 	if name == "" {
-		name = subdomain
+		name = subdomain + "-" + randomString(5)
 	}
 
 	parameter, err := api.loadParameter(c)
@@ -199,4 +197,14 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
 	}
 
 	return parameter, nil
+}
+
+const rsLetters = "0123456789abcdef"
+
+func randomString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = rsLetters[rand.Intn(len(rsLetters))]
+	}
+	return string(b)
 }

--- a/webapi.go
+++ b/webapi.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"time"
 
 	"gopkg.in/acidlemon/rocket.v2"
 )
@@ -203,7 +202,6 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
 const rsLetters = "0123456789abcdef"
 
 func randomString(n int) string {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = rsLetters[rand.Intn(len(rsLetters))]

--- a/webapi.go
+++ b/webapi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"time"
 
 	"gopkg.in/acidlemon/rocket.v2"
 )
@@ -202,6 +203,7 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
 const rsLetters = "0123456789abcdef"
 
 func randomString(n int) string {
+	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, n)
 	for i := range b {
 		b[i] = rsLetters[rand.Intn(len(rsLetters))]


### PR DESCRIPTION
ref #21 

Sorry, I realized problem #21, so I created this pr.
#21 cannot re-launch container same name because mirage termination only stop container and not remove. But off course, we want survey container's log after stop, so I think that it is not better to remove automatically.

So, I revised default container name with random 5 letters at suffix.