### PR TITLE
must choose streams

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -159,7 +159,9 @@ func (d *Docker) Logs(subdomain, since, tail string) ([]string, error) {
 		ErrorStream:  buf,
 		Tail:         tail,
 
-		Since: parsedSince,
+		Since:  parsedSince,
+		Stdout: true,
+		Stderr: true,
 	}
 
 	err := d.Client.Logs(opt)


### PR DESCRIPTION
`{"result":"fail to output logs API error (400): Bad parameters: you must choose at least one stream"}`

`/api/logs` を叩くと上記エラーが出るが、StderrやStdoutを選ぶ必要がある